### PR TITLE
Commit on behaf of Gervais

### DIFF
--- a/includes/derivatives.inc
+++ b/includes/derivatives.inc
@@ -46,7 +46,7 @@ function islandora_audio_create_mp3($file_uri) {
   $file = drupal_realpath($file_uri);
   $outfile = $file . '.mp3';
   $lame_url = variable_get('islandora_lame_url', '/usr/bin/lame');
-  $command = "$lame_url -V5 --vbr-new '${file}' '${outfile}'";
+  $command = "$lame_url -V5 --vbr-new --mp3input '${file}' '${outfile}'";
   $ret = FALSE;
   exec($command, $output, $ret);
   if ($ret == '0') {


### PR DESCRIPTION
From Gervais:

I tried to ingest a wav file and it failed... ran the command on the command
line and did a quick Google search on the error. The suggestion was to add the
following flag to the lame call " --mp3input" I tried it and it worked...

I changed line 49 in derivatives.inc to read:
$command = "$lame_url -V5 --vbr-new --mp3input '${file}' '${outfile}'";

Did some testing and I successfully ingested my test mp3's and the wav file that
was not working and both worked fine.... 
