### PR TITLE
Removed an incorrectly labeled argument.

### DIFF
--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -186,7 +186,7 @@ function islandora_audio_preprocess_islandora_audio(array &$variables) {
 /**
  * Implements hook_islandora_ingest_steps().
  */
-function islandora_audio_islandora_sp_audiocmodel_islandora_ingest_steps(array $configuration) {
+function islandora_audio_islandora_sp_audiocmodel_islandora_ingest_steps() {
   return array(
     'islandora_audio_upload' => array(
       'weight' => 10,


### PR DESCRIPTION
Array config is no longer passed, now the form state is.
