### PR TITLE
checksums for audio solution pack

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -43,8 +43,43 @@ function islandora_audio_admin(array $form, array &$form_state) {
       ),
     ),
   );
+
+  // Viewers.
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_audio_viewers', 'audio/mpeg');
+
+  // Checksumming.
+  $form['islandora_audio_checksum_configuration'] = array(
+    '#type' => 'fieldset',
+    '#title' => t('Checksum configuration'),
+  );
+
+  $form['islandora_audio_checksum_configuration']['islandora_audio_enable_checksum'] = array(
+    '#type' => 'checkbox',
+    '#title' => t('Enable checksum'),
+    '#description' => t('Enables checksum creation on the OBJ datastream for digital preservation purposes.'),
+    '#default_value' => variable_get('islandora_audio_enable_checksum', FALSE),
+  );
+
+  $form['islandora_audio_checksum_configuration']['islandora_audio_checksum_type'] = array(
+    '#type' => 'fieldset',
+    '#type' => 'select',
+    '#title' => t('Checksum type'),
+    '#states' => array(
+      'visible' => array(
+        ':input[name="islandora_audio_enable_checksum"]' => array('checked' => TRUE),
+      ),
+    ),
+    '#default_value' => variable_get('islandora_audio_checksum_type', 'DISABLED'),
+    '#multiple' => FALSE,
+    '#options' => array(
+      'MD5' => t('MD5'),
+      'SHA-1' => t('SHA-1'),
+      'SHA-256' => t('SHA-256'),
+      'SHA-385' => t('SHA-385'),
+      'SHA-512' => t('SHA-512'),
+    ),
+  );
   return system_settings_form($form);
 }
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -47,39 +47,6 @@ function islandora_audio_admin(array $form, array &$form_state) {
   // Viewers.
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_audio_viewers', 'audio/mpeg');
-
-  // Checksumming.
-  $form['islandora_audio_checksum_configuration'] = array(
-    '#type' => 'fieldset',
-    '#title' => t('Checksum configuration'),
-  );
-
-  $form['islandora_audio_checksum_configuration']['islandora_audio_enable_checksum'] = array(
-    '#type' => 'checkbox',
-    '#title' => t('Enable checksum'),
-    '#description' => t('Enables checksum creation on the OBJ datastream for digital preservation purposes.'),
-    '#default_value' => variable_get('islandora_audio_enable_checksum', FALSE),
-  );
-
-  $form['islandora_audio_checksum_configuration']['islandora_audio_checksum_type'] = array(
-    '#type' => 'fieldset',
-    '#type' => 'select',
-    '#title' => t('Checksum type'),
-    '#states' => array(
-      'visible' => array(
-        ':input[name="islandora_audio_enable_checksum"]' => array('checked' => TRUE),
-      ),
-    ),
-    '#default_value' => variable_get('islandora_audio_checksum_type', 'DISABLED'),
-    '#multiple' => FALSE,
-    '#options' => array(
-      'MD5' => t('MD5'),
-      'SHA-1' => t('SHA-1'),
-      'SHA-256' => t('SHA-256'),
-      'SHA-385' => t('SHA-385'),
-      'SHA-512' => t('SHA-512'),
-    ),
-  );
   return system_settings_form($form);
 }
 

--- a/includes/audio_upload.form.inc
+++ b/includes/audio_upload.form.inc
@@ -58,4 +58,6 @@ function islandora_audio_audio_upload_form_submit(array $form, array &$form_stat
   $ds->setContentFromFile($path, FALSE);
   $ds->label = $file->filename;
   $ds->mimetype = $file->filemime;
+  $ds->checksum = variable_get('islandora_audio_enable_checksum', FALSE);
+  $ds->checksumType = variable_get('islandora_audio_checksum_type', 'DISABLED');
 }

--- a/includes/audio_upload.form.inc
+++ b/includes/audio_upload.form.inc
@@ -58,6 +58,6 @@ function islandora_audio_audio_upload_form_submit(array $form, array &$form_stat
   $ds->setContentFromFile($path, FALSE);
   $ds->label = $file->filename;
   $ds->mimetype = $file->filemime;
-  $ds->checksum = variable_get('islandora_audio_enable_checksum', FALSE);
-  $ds->checksumType = variable_get('islandora_audio_checksum_type', 'DISABLED');
+  $ds->checksum = variable_get('islandora_checksum_enable_checksum', FALSE);
+  $ds->checksumType = variable_get('islandora_checksum_checksum_type', 'DISABLED');
 }


### PR DESCRIPTION
Allow users to enable checksumming the OBJ datastream, and allow users to select checksum type if checksumming is enabled.

Not sure if this is the best approach in so far as enabling checksumming. Should we do this on individual solution pack or at a higher level, like the Islandora configuration page, or a checksum solution pack?

If this is the right approach, I can take care of writing this the for other main solution packs.
