### PR TITLE
Islandora 1478

### DIFF
--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -29,7 +29,7 @@ function islandora_audio_admin(array $form, array &$form_state) {
       '#description' => t('!LAME is required to create derivatives files.<br/>!msg',
                       array(
                         '!LAME' => l(t('LAME'), 'http://lame.sourceforge.net/'),
-                        '!msg' => islandora_executable_available_message($lame),
+                        '!msg' =>  t("Put @no_deriv in the text field to indicate that derivatives should not be produced on ingest.<br/>", array('@no_deriv' => ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE)).islandora_audio_admin_form_check_lame_for_no_derivative_message($lame),
                       )),
       '#default_value' => $lame,
       '#size' => 20,
@@ -46,6 +46,24 @@ function islandora_audio_admin(array $form, array &$form_state) {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_audio_viewers', 'audio/mpeg');
   return system_settings_form($form);
+}
+
+/**
+ * Determine the message to show to the user based on whether the path indicator
+ * is set to not run the derivative
+ *
+ * @param string $path
+ *   The absolute path to an executable to check for availability, or the special set indicating that a derivative should not be produced
+ * 
+ * @return string
+ *   A message in html detailing if the given executable is accessible, or that the user indicated that a derviative should not be produced
+ */
+function islandora_audio_admin_form_check_lame_for_no_derivative_message($lame){
+  if ($lame !== ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE){
+    return islandora_executable_available_message($lame);
+  }else{
+    return t("Derivative creation will not be attempted.");
+  }
 }
 
 /**

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -23,13 +23,20 @@ function islandora_audio_admin(array $form, array &$form_state) {
   };
   $lame = $get_default_value('islandora_lame_url', '/usr/bin/lame');
   $form = array(
+    'islandora_defer_audio_derivatives_on_ingest' => array(
+      '#type' => 'checkbox',
+      '#title' => t('Defer audio derivative generation during ingest'),
+      '#description' => t('Prevent audio derivatives from running during ingest,
+            useful if derivatives are to be created by an external service.'),
+      '#default_value' => variable_get('islandora_defer_audio_derivatives_on_ingest', FALSE),
+    ),
     'islandora_lame_url' => array(
       '#type' => 'textfield',
       '#title' => t("Path to LAME"),
       '#description' => t('!LAME is required to create derivatives files.<br/>!msg',
                       array(
                         '!LAME' => l(t('LAME'), 'http://lame.sourceforge.net/'),
-                        '!msg' =>  t("Put @no_deriv in the text field to indicate that derivatives should not be produced on ingest.<br/>", array('@no_deriv' => ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE)).islandora_audio_admin_form_check_lame_for_no_derivative_message($lame),
+                        '!msg' =>  islandora_executable_available_message($lame),
                       )),
       '#default_value' => $lame,
       '#size' => 20,
@@ -46,24 +53,6 @@ function islandora_audio_admin(array $form, array &$form_state) {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_audio_viewers', 'audio/mpeg');
   return system_settings_form($form);
-}
-
-/**
- * Determine the message to show to the user based on whether the path indicator
- * is set to not run the derivative
- *
- * @param string $path
- *   The absolute path to an executable to check for availability, or the special set indicating that a derivative should not be produced
- * 
- * @return string
- *   A message in html detailing if the given executable is accessible, or that the user indicated that a derviative should not be produced
- */
-function islandora_audio_admin_form_check_lame_for_no_derivative_message($lame){
-  if ($lame !== ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE){
-    return islandora_executable_available_message($lame);
-  }else{
-    return t("Derivative creation will not be attempted.");
-  }
 }
 
 /**

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -23,12 +23,12 @@ function islandora_audio_admin(array $form, array &$form_state) {
   };
   $lame = $get_default_value('islandora_lame_url', '/usr/bin/lame');
   $form = array(
-    'islandora_defer_audio_derivatives_on_ingest' => array(
+    'islandora_audio_defer_derivatives_on_ingest' => array(
       '#type' => 'checkbox',
       '#title' => t('Defer audio derivative generation during ingest'),
       '#description' => t('Prevent audio derivatives from running during ingest,
             useful if derivatives are to be created by an external service.'),
-      '#default_value' => variable_get('islandora_defer_audio_derivatives_on_ingest', FALSE),
+      '#default_value' => variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE),
     ),
     'islandora_lame_url' => array(
       '#type' => 'textfield',

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -36,7 +36,7 @@ function islandora_audio_admin(array $form, array &$form_state) {
       '#description' => t('!LAME is required to create derivatives files.<br/>!msg',
                       array(
                         '!LAME' => l(t('LAME'), 'http://lame.sourceforge.net/'),
-                        '!msg' =>  islandora_executable_available_message($lame),
+                        '!msg' => islandora_executable_available_message($lame),
                       )),
       '#default_value' => $lame,
       '#size' => 20,

--- a/islandora_audio.install
+++ b/islandora_audio.install
@@ -17,9 +17,10 @@ function islandora_audio_requirements($phase) {
   if (!is_executable($lame)) {
     $value = $t('Not Found');
     $description = $t('Islandora is not configured to process audio. Click <a href="http://lame.sourceforge.net/download.php">here</a> for installation instructions.');
-    if (variable_get('islandora_defer_audio_derivatives_on_ingest', FALSE)){
+    if (variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE)){
       $severity = REQUIREMENT_INFO;
-    }else{
+    }
+    else {
       $severity = REQUIREMENT_WARNING;
     }
   }

--- a/islandora_audio.install
+++ b/islandora_audio.install
@@ -18,7 +18,7 @@ function islandora_audio_requirements($phase) {
     $value = $t('Not Found');
     $description = $t('Islandora is not configured to process audio. Click <a href="http://lame.sourceforge.net/download.php">here</a> for installation instructions.');
     $severity = REQUIREMENT_WARNING;
-    if (variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE)){
+    if (variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE)) {
       $severity = REQUIREMENT_INFO;
     }
   }

--- a/islandora_audio.install
+++ b/islandora_audio.install
@@ -17,11 +17,9 @@ function islandora_audio_requirements($phase) {
   if (!is_executable($lame)) {
     $value = $t('Not Found');
     $description = $t('Islandora is not configured to process audio. Click <a href="http://lame.sourceforge.net/download.php">here</a> for installation instructions.');
+    $severity = REQUIREMENT_WARNING;
     if (variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE)){
       $severity = REQUIREMENT_INFO;
-    }
-    else {
-      $severity = REQUIREMENT_WARNING;
     }
   }
   return array(

--- a/islandora_audio.install
+++ b/islandora_audio.install
@@ -48,6 +48,10 @@ function islandora_audio_install() {
 function islandora_audio_uninstall() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   islandora_install_solution_pack('islandora_audio', 'uninstall');
-  $variables = array('islandora_audio_viewers', 'islandora_lame_url');
+  $variables = array(
+    'islandora_audio_defer_derivatives_on_ingest',
+    'islandora_audio_viewers',
+    'islandora_lame_url',
+  );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_audio.install
+++ b/islandora_audio.install
@@ -16,8 +16,13 @@ function islandora_audio_requirements($phase) {
   $severity = REQUIREMENT_OK;
   if (!is_executable($lame)) {
     $value = $t('Not Found');
-    $description = $t('Islandora will not be able to process audio. Click <a href="http://lame.sourceforge.net/download.php">here</a> for installation instructions.');
-    $severity = REQUIREMENT_WARNING;
+    if ($lame === ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE){
+      $severity = REQUIREMENT_INFO;
+      $description = $t('Islandora is not configured to process audio. Click <a href="http://lame.sourceforge.net/download.php">here</a> for installation instructions.');
+    }else{
+      $severity = REQUIREMENT_WARNING;
+      $description = $t('Islandora will not be able to process audio. Click <a href="http://lame.sourceforge.net/download.php">here</a> for installation instructions.');
+    }
   }
   return array(
     array(

--- a/islandora_audio.install
+++ b/islandora_audio.install
@@ -17,7 +17,7 @@ function islandora_audio_requirements($phase) {
   if (!is_executable($lame)) {
     $value = $t('Not Found');
     $description = $t('Islandora is not configured to process audio. Click <a href="http://lame.sourceforge.net/download.php">here</a> for installation instructions.');
-    if ($lame === ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE){
+    if (variable_get('islandora_defer_audio_derivatives_on_ingest', FALSE)){
       $severity = REQUIREMENT_INFO;
     }else{
       $severity = REQUIREMENT_WARNING;

--- a/islandora_audio.install
+++ b/islandora_audio.install
@@ -16,12 +16,11 @@ function islandora_audio_requirements($phase) {
   $severity = REQUIREMENT_OK;
   if (!is_executable($lame)) {
     $value = $t('Not Found');
+    $description = $t('Islandora is not configured to process audio. Click <a href="http://lame.sourceforge.net/download.php">here</a> for installation instructions.');
     if ($lame === ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE){
       $severity = REQUIREMENT_INFO;
-      $description = $t('Islandora is not configured to process audio. Click <a href="http://lame.sourceforge.net/download.php">here</a> for installation instructions.');
     }else{
       $severity = REQUIREMENT_WARNING;
-      $description = $t('Islandora will not be able to process audio. Click <a href="http://lame.sourceforge.net/download.php">here</a> for installation instructions.');
     }
   }
   return array(

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -5,6 +5,9 @@
  * Handles the creation/display of islandora:sp-audioCModel objects.
  */
 
+// Define the "path" to indicate that the PROXY_MP3 derivative should not be attempted
+define('ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE', '<none>');
+
 /**
  * Implements hook_menu().
  */
@@ -210,24 +213,28 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_ingest_steps() {
  * Implements hook_CMODEL_PID_islandora_derivative().
  */
 function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
-  return array(
-    array(
-      'source_dsid' => 'OBJ',
-      'destination_dsid' => 'PROXY_MP3',
-      'weight' => '0',
-      'function' => array(
-        'islandora_audio_create_mp3',
+  if (variable_get('islandora_lame_url', '/usr/bin/lame') === ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE){
+    return array();
+  }else{
+    return array(
+      array(
+        'source_dsid' => 'OBJ',
+        'destination_dsid' => 'PROXY_MP3',
+        'weight' => '0',
+        'function' => array(
+          'islandora_audio_create_mp3',
+        ),
+        'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
       ),
-      'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
-    ),
-    array(
-      'source_dsid' => NULL,
-      'destination_dsid' => 'TN',
-      'weight' => 1,
-      'function' => array(
-        'islandora_audio_create_thumbnail',
+      array(
+        'source_dsid' => NULL,
+        'destination_dsid' => 'TN',
+        'weight' => 1,
+        'function' => array(
+          'islandora_audio_create_thumbnail',
+        ),
+        'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
       ),
-      'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
-    ),
-  );
+    );
+  }
 }

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -5,9 +5,6 @@
  * Handles the creation/display of islandora:sp-audioCModel objects.
  */
 
-// Define the "path" to indicate that the PROXY_MP3 derivative should not be attempted
-define('ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE', '<none>');
-
 /**
  * Implements hook_menu().
  */
@@ -213,7 +210,7 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_ingest_steps() {
  * Implements hook_CMODEL_PID_islandora_derivative().
  */
 function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
-  if (variable_get('islandora_lame_url', '/usr/bin/lame') === ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE){
+  if (variable_get('islandora_defer_audio_derivatives_on_ingest', FALSE)){
     return array(
       array(
         'source_dsid' => NULL,

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -210,23 +210,20 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_ingest_steps() {
  * Implements hook_CMODEL_PID_islandora_derivative().
  */
 function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
-  $create_thumbnail_derivative = array(
-    'source_dsid' => NULL,
-    'destination_dsid' => 'TN',
-    'weight' => 1,
-    'function' => array(
-      'islandora_audio_create_thumbnail',
-    ),
-    'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
-  );
-
-  if (variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE)) {
-    return array(
-      $create_thumbnail_derivative,
-    );
-  }
-  return array(
+  $derivative_list = array(
     array(
+      'source_dsid' => NULL,
+      'destination_dsid' => 'TN',
+      'weight' => 1,
+      'function' => array(
+        'islandora_audio_create_thumbnail',
+      ),
+      'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
+    ),
+  );
+  
+  if (!variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE)) {
+    $derivative_list[] = array(
       'source_dsid' => 'OBJ',
       'destination_dsid' => 'PROXY_MP3',
       'weight' => '0',
@@ -234,7 +231,7 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
         'islandora_audio_create_mp3',
       ),
       'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
-    ),
-    $create_thumbnail_derivative,
-  );
+    );
+  }
+  return $derivative_list;
 }

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -214,7 +214,17 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_ingest_steps() {
  */
 function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
   if (variable_get('islandora_lame_url', '/usr/bin/lame') === ISLANDORA_AUDIO_NO_TRIGGER_DERIVATIVE){
-    return array();
+    return array(
+      array(
+        'source_dsid' => NULL,
+        'destination_dsid' => 'TN',
+        'weight' => 1,
+        'function' => array(
+          'islandora_audio_create_thumbnail',
+        ),
+        'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
+      ),
+    );
   }else{
     return array(
       array(

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -210,7 +210,7 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_ingest_steps() {
  * Implements hook_CMODEL_PID_islandora_derivative().
  */
 function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
-  if (variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE)){
+  if (variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE)) {
     return array(
       array(
         'source_dsid' => NULL,

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -210,17 +210,19 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_ingest_steps() {
  * Implements hook_CMODEL_PID_islandora_derivative().
  */
 function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
+  $create_thumbnail_derivative = array(
+    'source_dsid' => NULL,
+    'destination_dsid' => 'TN',
+    'weight' => 1,
+    'function' => array(
+      'islandora_audio_create_thumbnail',
+    ),
+    'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
+  );
+
   if (variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE)) {
     return array(
-      array(
-        'source_dsid' => NULL,
-        'destination_dsid' => 'TN',
-        'weight' => 1,
-        'function' => array(
-          'islandora_audio_create_thumbnail',
-        ),
-        'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
-      ),
+      $create_thumbnail_derivative,
     );
   }
   return array(
@@ -233,14 +235,6 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
       ),
       'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
     ),
-    array(
-      'source_dsid' => NULL,
-      'destination_dsid' => 'TN',
-      'weight' => 1,
-      'function' => array(
-        'islandora_audio_create_thumbnail',
-      ),
-      'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
-    ),
+    $create_thumbnail_derivative,
   );
 }

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -222,7 +222,8 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
         'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
       ),
     );
-  }else{
+  }
+  else {
     return array(
       array(
         'source_dsid' => 'OBJ',

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -221,7 +221,6 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
       'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
     ),
   );
-  
   if (!variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE)) {
     $derivative_list[] = array(
       'source_dsid' => 'OBJ',

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -223,26 +223,24 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
       ),
     );
   }
-  else {
-    return array(
-      array(
-        'source_dsid' => 'OBJ',
-        'destination_dsid' => 'PROXY_MP3',
-        'weight' => '0',
-        'function' => array(
-          'islandora_audio_create_mp3',
-        ),
-        'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
+  return array(
+    array(
+      'source_dsid' => 'OBJ',
+      'destination_dsid' => 'PROXY_MP3',
+      'weight' => '0',
+      'function' => array(
+        'islandora_audio_create_mp3',
       ),
-      array(
-        'source_dsid' => NULL,
-        'destination_dsid' => 'TN',
-        'weight' => 1,
-        'function' => array(
-          'islandora_audio_create_thumbnail',
-        ),
-        'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
+      'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
+    ),
+    array(
+      'source_dsid' => NULL,
+      'destination_dsid' => 'TN',
+      'weight' => 1,
+      'function' => array(
+        'islandora_audio_create_thumbnail',
       ),
-    );
-  }
+      'file' => drupal_get_path('module', 'islandora_audio') . '/includes/derivatives.inc',
+    ),
+  );
 }

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -210,7 +210,7 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_ingest_steps() {
  * Implements hook_CMODEL_PID_islandora_derivative().
  */
 function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
-  if (variable_get('islandora_defer_audio_derivatives_on_ingest', FALSE)){
+  if (variable_get('islandora_audio_defer_derivatives_on_ingest', FALSE)){
     return array(
       array(
         'source_dsid' => NULL,


### PR DESCRIPTION
https://jira.duraspace.org/browse/ISLANDORA-1478

Putting &lt;none&gt; as the lame encoder will allow the solution pack to run update.php without overrides.

Intended for when you want to create the mp3 for PROXY_MP3 on a backend server instead of on the Drupal server.
