### PR TITLE
OBJ fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ Install as usual, see [this](https://drupal.org/documentation/install/modules-th
 
 Set the path for `lame` and select a viewer in Administration » Islandora » Audio Collection (admin/islandora/audio).
 
-![Configuration](https://camo.githubusercontent.com/97cad9681ab47b9e8c5dadde7970ce46f3ce2278/687474703a2f2f692e696d6775722e636f6d2f6a7837336c454b2e706e67)
+An option also exists to fall back to the OBJ datastream in viewers if the PROXY_MP3 datastream doesn't exist and the OBJ can be played.
+
+![Configuration](https://cloud.githubusercontent.com/assets/3406327/11278393/1f340714-8ec1-11e5-8d08-3bce15529b42.png)
 
 Current viewers that can be configured include:
 

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -42,6 +42,12 @@ function islandora_audio_admin(array $form, array &$form_state) {
         'event' => 'change',
       ),
     ),
+    'islandora_audio_obj_fallback' => array(
+      '#type' => 'checkbox',
+      '#title' => t('Use OBJ As Fallback'),
+      '#description' => t('Optionally attempt to fall back to the OBJ datastream for playback if the PROXY_MP3 is not present.'),
+      '#default_value' => $get_default_value('islandora_audio_obj_fallback', FALSE),
+    );
   );
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_audio_viewers', 'audio/mpeg');

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -46,7 +46,7 @@ function islandora_audio_admin(array $form, array &$form_state) {
       '#type' => 'checkbox',
       '#title' => t('Use OBJ As Fallback'),
       '#description' => t('Optionally attempt to fall back to the OBJ datastream for playback if the PROXY_MP3 is not present.'),
-      '#default_value' => $get_default_value('islandora_audio_obj_fallback', FALSE),
+      '#default_value' => $get_default_value('islandora_audio_obj_fallback', TRUE),
     ),
   );
   module_load_include('inc', 'islandora', 'includes/solution_packs');

--- a/includes/admin.form.inc
+++ b/includes/admin.form.inc
@@ -47,7 +47,7 @@ function islandora_audio_admin(array $form, array &$form_state) {
       '#title' => t('Use OBJ As Fallback'),
       '#description' => t('Optionally attempt to fall back to the OBJ datastream for playback if the PROXY_MP3 is not present.'),
       '#default_value' => $get_default_value('islandora_audio_obj_fallback', FALSE),
-    );
+    ),
   );
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   $form += islandora_viewers_form('islandora_audio_viewers', 'audio/mpeg');

--- a/includes/utilities.inc
+++ b/includes/utilities.inc
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @file
+ * Utilities functions for the audio SP.
+ */
+
+/**
+ * Determines if a datastream is valid for playback in the browser.
+ *
+ * @param AbstractDatastream $datastream
+ *   The datastream to check.
+ *
+ * @return bool
+ *   TRUE if the datastream can be played; FALSE otherwise.
+ */
+function islandora_audio_datastream_valid_for_playback(AbstractDatastream $datastream) {
+  if ($datastream->mimetype == 'audio/mpeg' || $datastream->mimetype == 'audio/mp4') {
+    return TRUE;
+  }
+  // @TODO: This is currently a simple check against types supported by all
+  // browsers. We may want to be more granular in the future. We may also want
+  // to offset this responsibility to individual viewers.
+  return FALSE;
+}

--- a/islandora_audio.install
+++ b/islandora_audio.install
@@ -43,6 +43,10 @@ function islandora_audio_install() {
 function islandora_audio_uninstall() {
   module_load_include('inc', 'islandora', 'includes/solution_packs');
   islandora_install_solution_pack('islandora_audio', 'uninstall');
-  $variables = array('islandora_audio_viewers', 'islandora_lame_url');
+  $variables = array(
+    'islandora_audio_viewers',
+    'islandora_lame_url',
+    'islandora_audio_obj_fallback',
+  );
   array_walk($variables, 'variable_del');
 }

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -180,7 +180,7 @@ function islandora_audio_preprocess_islandora_audio(array &$variables) {
       "url" => $audio_url,
       "mime" => 'audio/mpeg',
     );
-    
+
     module_load_include('inc', 'islandora', 'includes/solution_packs');
     $viewer = islandora_get_viewer($audio_params, 'islandora_audio_viewers', $islandora_object);
 
@@ -193,7 +193,7 @@ function islandora_audio_preprocess_islandora_audio(array &$variables) {
     else {
       $variables['islandora_content'] = l($islandora_object->label, $audio_url);
     }
-  } 
+  }
 }
 
 /**

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -166,29 +166,34 @@ function islandora_audio_preprocess_islandora_audio(array &$variables) {
   }
 
   // Audio player.
-  if (isset($islandora_object['PROXY_MP3']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['PROXY_MP3'])) {
-    $audio_url = url("islandora/object/{$islandora_object->id}/datastream/PROXY_MP3", array('absolute' => TRUE));
+  // Determine whether to attempt to use the OBJ or PROXY_MP3.
+  module_load_include('inc', 'islandora_audio', 'includes/utilities');
+  $dsid = !isset($islandora_object['PROXY_MP3']) &&
+    variable_get('islandora_audio_obj_fallback', FALSE) &&
+    isset($islandora_object['OBJ']) &&
+    islandora_audio_datastream_valid_for_playback($islandora_object['OBJ']) ? 'OBJ' : 'PROXY_MP3';
+
+  if (islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object[$dsid])) {
+    $audio_url = url("islandora/object/{$islandora_object->id}/datastream/$dsid", array('absolute' => TRUE));
 
     $audio_params += array(
       "url" => $audio_url,
       "mime" => 'audio/mpeg',
     );
-  }
+    
+    module_load_include('inc', 'islandora', 'includes/solution_packs');
+    $viewer = islandora_get_viewer($audio_params, 'islandora_audio_viewers', $islandora_object);
 
-  module_load_include('inc', 'islandora', 'includes/solution_packs');
-  $viewer = islandora_get_viewer($audio_params, 'islandora_audio_viewers', $islandora_object);
-
-  if ($viewer) {
-    $variables['islandora_content'] = $viewer;
-  }
-  elseif (isset($variables['islandora_thumbnail_img']) && isset($islandora_object['PROXY_MP3']) &&
-    islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['PROXY_MP3'])) {
-
-    $variables['islandora_content'] = l($variables['islandora_thumbnail_img'], $audio_url, array('html' => TRUE));
-  }
-  elseif (isset($islandora_object['PROXY_MP3']) && islandora_datastream_access(ISLANDORA_VIEW_OBJECTS, $islandora_object['PROXY_MP3'])) {
-    $variables['islandora_content'] = l($islandora_object->label, $audio_url);
-  }
+    if ($viewer) {
+      $variables['islandora_content'] = $viewer;
+    }
+    elseif (isset($variables['islandora_thumbnail_img'])) {
+      $variables['islandora_content'] = l($variables['islandora_thumbnail_img'], $audio_url, array('html' => TRUE));
+    }
+    else {
+      $variables['islandora_content'] = l($islandora_object->label, $audio_url);
+    }
+  } 
 }
 
 /**

--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -169,7 +169,7 @@ function islandora_audio_preprocess_islandora_audio(array &$variables) {
   // Determine whether to attempt to use the OBJ or PROXY_MP3.
   module_load_include('inc', 'islandora_audio', 'includes/utilities');
   $dsid = !isset($islandora_object['PROXY_MP3']) &&
-    variable_get('islandora_audio_obj_fallback', FALSE) &&
+    variable_get('islandora_audio_obj_fallback', TRUE) &&
     isset($islandora_object['OBJ']) &&
     islandora_audio_datastream_valid_for_playback($islandora_object['OBJ']) ? 'OBJ' : 'PROXY_MP3';
 


### PR DESCRIPTION
**Jira:** https://jira.duraspace.org/browse/ISLANDORA-1549
# What does this Pull Request do?

Adds an administrator-toggleable fallback to the OBJ datastream if the PROXY_MP3 doesn't exist and the OBJ can be played by the browser.
# How should this be tested?

This should be tested with several different OBJ datastreams, including ones that are invalid for playback in the browser. There's some involved logic here, but the order of operations should go:
- If the PROXY_MP3 datastream is present, this should be used as the DSID.
- If no PROXY_MP3 datastream is present, then
- If the new OBJ fallback flag added in this PR is set, and an OBJ datastream exists, and the OBJ datastream is an audio/mp4 or audio/mpeg datastream, then OBJ should be used as the DSID.
- If the chosen datastream is accessible by the current user, the viewer should be loaded and the datastream should be used for playback.
- If no datastream is valid, no viewer should be loaded.
# Background context:

We do a similar thing with Islandora Video Solution Pack; it makes sense not to generate and store superfluous datastreams if the original upload is suitable for playback.
# Screenshots (if appropriate)
## Before Screenshot

![Before Screenshot](https://camo.githubusercontent.com/97cad9681ab47b9e8c5dadde7970ce46f3ce2278/687474703a2f2f692e696d6775722e636f6d2f6a7837336c454b2e706e67)
![After Screenshot](https://cloud.githubusercontent.com/assets/3406327/11278393/1f340714-8ec1-11e5-8d08-3bce15529b42.png)
# Additional Notes:
- **Does this change require documentation to be updated?** Yep! README should be up to date.
- **Does this change add any new dependencies?** Nope, it's all right in the module.
- **Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)?** No, this is independent of the repository.
- **Could this change impact execution of existing code?** I don't believe so.

**Tagging:** @Islandora/7-x-1-x-committers plus component manager @rosiel 

---

QA Dan
_Developer_
**[discoverygarden inc.](http://www.discoverygarden.ca) | Managing Digital Content**
