### PR TITLE
Modified hook to implement template_preprocess_HOOK()

### DIFF
--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -117,9 +117,9 @@ function islandora_audio_theme($existing, $type, $theme, $path) {
 }
 
 /**
- * Implements template_preprocess_hook().
+ * Implements template_preprocess_HOOK().
  */
-function islandora_audio_preprocess_islandora_audio(array &$variables) {
+function template_preprocess_islandora_audio(array &$variables) {
   drupal_add_js('misc/form.js');
   drupal_add_js('misc/collapse.js');
   $islandora_object = $variables['islandora_object'];


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1071

# What does this Pull Request do?

This pull request ensures that when a function in this module implements hook_theme() that the template_preprocess hook is called to allow overriding variables further down the processing chain.

# What's new?

The function name has been changed to begin with ‘template’ instead of islandora_solution_pack_audio.

# Interested parties

@Islandora/7-x-1-x-committers
