### PR TITLE
Make mp3 download with the correct extension.

### DIFF
--- a/islandora_audio.module
+++ b/islandora_audio.module
@@ -239,3 +239,14 @@ function islandora_audio_islandora_sp_audiocmodel_islandora_derivative() {
   }
   return $derivative_list;
 }
+
+/**
+ * Implements hook_file_mimetype_mapping_alter().
+ */
+function islandora_audio_file_mimetype_mapping_alter(&$mapping) {
+  // Make sure the mapping is sensible for audio/mpeg by removing
+  // it from array and adding it to end so it has priority.
+  $code = $mapping['extensions']['mp3'];
+  unset($mapping['extensions']['mp3']);
+  $mapping['extensions']['mp3'] = $code;
+}


### PR DESCRIPTION
## JIRA Ticket

https://jira.duraspace.org/browse/ISLANDORA-2075

Related to: 
https://github.com/Islandora/islandora_solution_pack_video/pull/139

## What does this Pull Request do?

Fixes the file extension when downloading audio files from Islandora.

## What's new?

Add `hook_file_mimetype_mapping_alter` so that `audio/mpeg` has the correct extension.

## How should this be tested?

* Create a new audio object
* Go into the manage tab and click `download` on the MP3 datastream.
* Before patch it should give a filename like MP3.mp2 
* After patch it should give MP3.mp3

## Additional Notes:

The mime is defined in Drupal here:
https://github.com/drupal/drupal/blob/7.x/includes/file.mimetypes.inc#L641

# Interested parties
@Islandora/7-x-1-x-committers